### PR TITLE
Fix footer font weight

### DIFF
--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -353,7 +353,6 @@ h4
     p, a
         color: #fff
         font-size: 18px
-        font-weight: 350
         text-align: center
 
         @media screen and (max-width: 700px)


### PR DESCRIPTION
Fix enhancement #18 as footer font weight was too thin to be readable, especially on mobile devices