### PR TITLE
Force Jest and gulp colored output

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/server.js",
     "stop": "pkill --signal SIGINT nodeWebServer",
     "postinstall": "npx gulp",
-    "test": "npx gulp && npx jest"
+    "test": "npx gulp && npx jest --colors"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "node dist/server.js",
     "stop": "pkill --signal SIGINT nodeWebServer",
-    "postinstall": "npx gulp",
-    "test": "npx gulp && npx jest --colors"
+    "postinstall": "npx gulp --color",
+    "test": "npx gulp --color && npx jest --colors"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Force color output in Jest and gulp for Github Actions

Now the report looks like this:

![image](https://user-images.githubusercontent.com/14943421/112041794-153a1900-8b47-11eb-91ea-5009778fcd98.png)

Instead of this:

![image](https://user-images.githubusercontent.com/14943421/112041824-1d925400-8b47-11eb-93b1-b456f87e9a2e.png)
