### PR TITLE
Fix Orbital Game Jam Discord URL

### DIFF
--- a/src/pages/commissions/commission-list.json
+++ b/src/pages/commissions/commission-list.json
@@ -153,7 +153,7 @@
             }
         ],
         "social": {
-            "Discord": "discord.gg/mCUYyCQ",
+            "Discord": "https://discord.gg/mCUYyCQ",
             "Site web": "http://orbital-game-jam.ch/",
             "Email": "mailto:orbitalgamejam@groupes.epfl.ch"
         }


### PR DESCRIPTION
J'ai trouvé ça en faisant fouillant le site pour EnigmatIC 😅
Sans le http(s):// devant, ça fait un lien relatif qui pointe vers : https://clic.epfl.ch/commissions/discord.gg/mCUYyCQ