### PR TITLE
ci: fix jobs running twice on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,11 @@ name: nodejs-ci
 
 on:
   push:
-  pull_request: 
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ name: nodejs-ci
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
#173 introduced a bug in the Github Actions workflow where every action is ran twice when a PR is created.

CI jobs should run on every new PR and pushes to the PR branch (pull_request to master event), and on merges to master (push to master event).

According to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request the patched configuration should do exactly that, and avoid running twice when a PR is created by mutually excluding both events.

Please squash, second commit is a typo