### PR TITLE
Change registration link #252

### DIFF
--- a/src/pages/events/icbd/icbd-page-view.njk
+++ b/src/pages/events/icbd/icbd-page-view.njk
@@ -62,7 +62,7 @@
                     </p>
 
                     <p class="center-text registration">
-                        <a href="https://go.epfl.ch/icbd-inscriptions" target="_blank">
+                        <a href="https://go.epfl.ch/icbd-form" target="_blank">
                             Registration
                             <i class="fas fa-arrow-right"></i>
                         </a>


### PR DESCRIPTION
the email and QR code go.epfl.ch link nows points to the website instead of the gform
the website now points towards the new gform link